### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lgd_monitor_site.yml
+++ b/.github/workflows/lgd_monitor_site.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: docker/setup-buildx-action@v3.3.0
       - name: Build Image
-        uses: docker/build-push-action@v6.1.0
+        uses: docker/build-push-action@v6.2.0
         with:
           context: lgd
           load: true

--- a/.github/workflows/lgd_run.yml
+++ b/.github/workflows/lgd_run.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: docker/setup-buildx-action@v3.3.0
       - name: Build Image
-        uses: docker/build-push-action@v6.1.0
+        uses: docker/build-push-action@v6.2.0
         with:
           context: lgd
           load: true

--- a/.github/workflows/soi_parse.yml
+++ b/.github/workflows/soi_parse.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: docker/setup-buildx-action@v3.3.0
       - name: Build Image
-        uses: docker/build-push-action@v6.1.0
+        uses: docker/build-push-action@v6.2.0
         with:
           context: maps/SOI
           load: true

--- a/.github/workflows/soi_unavailable_run.yml
+++ b/.github/workflows/soi_unavailable_run.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: docker/setup-buildx-action@v3.3.0
       - name: Build Image
-        uses: docker/build-push-action@v6.1.0
+        uses: docker/build-push-action@v6.2.0
         with:
           context: maps/SOI
           load: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.2.0](https://github.com/docker/build-push-action/releases/tag/v6.2.0)** on 2024-06-26T13:09:11Z
