### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lgd_monitor_site.yml
+++ b/.github/workflows/lgd_monitor_site.yml
@@ -27,9 +27,9 @@ jobs:
       changes: ${{ steps.monitor-changes.outputs.changes }}
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: docker/setup-buildx-action@v3.3.0
+      - uses: docker/setup-buildx-action@v3.4.0
       - name: Build Image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@v6.3.0
         with:
           context: lgd
           load: true

--- a/.github/workflows/lgd_run.yml
+++ b/.github/workflows/lgd_run.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           swap-size-gb: 10
       - uses: actions/checkout@v4.1.7
-      - uses: docker/setup-buildx-action@v3.3.0
+      - uses: docker/setup-buildx-action@v3.4.0
       - name: Build Image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@v6.3.0
         with:
           context: lgd
           load: true

--- a/.github/workflows/soi_parse.yml
+++ b/.github/workflows/soi_parse.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           swap-size-gb: 12
       - uses: actions/checkout@v4.1.7
-      - uses: docker/setup-buildx-action@v3.3.0
+      - uses: docker/setup-buildx-action@v3.4.0
       - name: Build Image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@v6.3.0
         with:
           context: maps/SOI
           load: true

--- a/.github/workflows/soi_unavailable_run.yml
+++ b/.github/workflows/soi_unavailable_run.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.7
-      - uses: docker/setup-buildx-action@v3.3.0
+      - uses: docker/setup-buildx-action@v3.4.0
       - name: Build Image
-        uses: docker/build-push-action@v6.2.0
+        uses: docker/build-push-action@v6.3.0
         with:
           context: maps/SOI
           load: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.4.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.4.0)** on 2024-07-04T07:35:04Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.3.0](https://github.com/docker/build-push-action/releases/tag/v6.3.0)** on 2024-07-03T07:47:10Z
