### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lgd_wikidata_sync_check.yml
+++ b/.github/workflows/lgd_wikidata_sync_check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.1.1
         with:
           python-version: '3.10'
 

--- a/.github/workflows/rfcoverage_run.yml
+++ b/.github/workflows/rfcoverage_run.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Setup python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.1.1
         with:
           python-version: '3.10'
 

--- a/.github/workflows/soi_run_deprecated.yml
+++ b/.github/workflows/soi_run_deprecated.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends tesseract-ocr libgl1-mesa-glx libgdal-dev gdal-bin
 
       - name: Setup python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5.1.1
         with:
           python-version: '3.9.4'
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.1](https://github.com/actions/setup-python/releases/tag/v5.1.1)** on 2024-07-10T14:00:28Z
